### PR TITLE
Fix the fixedDepth bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ some other elements for instance based on `data-type` of current element and oth
 
 ### Methods
 
+`serialize`:
 You can get a serialised object with all `data-*` attributes for each item.
 ```js
 $('.dd').nestable('serialize');
@@ -117,7 +118,7 @@ The serialised JSON for the example above would be:
 ```json
 [{"id":1},{"id":2},{"id":3,"children":[{"id":4},{"id":5,"foo":"bar"}]}]
 ```
-
+`destroy`:
 You can deactivate the plugin by running
 ```js
     $('.dd').nestable('destroy');

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ The serialised JSON for the example above would be:
 [{"id":1},{"id":2},{"id":3,"children":[{"id":4},{"id":5,"foo":"bar"}]}]
 ```
 
++You can deactivate the plugin by running
+```js
++    $('.dd').nestable('destroy');
+```
++
+
 ### On the fly nestable generation
 
 You can passed serialized JSON as an option if you like to dynamically generate a Nestable list:

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ The serialised JSON for the example above would be:
 [{"id":1},{"id":2},{"id":3,"children":[{"id":4},{"id":5,"foo":"bar"}]}]
 ```
 
-+You can deactivate the plugin by running
+You can deactivate the plugin by running
 ```js
-+    $('.dd').nestable('destroy');
+    $('.dd').nestable('destroy');
 ```
-+
+
 
 ### On the fly nestable generation
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -184,20 +184,20 @@
                 list.w.on(eMove, onMoveEvent);
                 list.w.on(eEnd, onEndEvent);
             }
-			
+
             var destroyNestable = function()
             {
-           	 	if(hasTouch) {
-              	  list.el[0].removeEventListener(eStart, onStartEvent, false);
-              	  window.removeEventListener(eMove, onMoveEvent, false);
-              	  window.removeEventListener(eEnd, onEndEvent, false);
-              	  window.removeEventListener(eCancel, onEndEvent, false);
-          	  	}
-          	  	else {
-              	  list.el.off(eStart, onStartEvent);
-               	  list.w.off(eMove, onMoveEvent);
-              	  list.w.off(eEnd, onEndEvent);
-				}
+                if(hasTouch) {
+                    list.el[0].removeEventListener(eStart, onStartEvent, false);
+                    window.removeEventListener(eMove, onMoveEvent, false);
+                    window.removeEventListener(eEnd, onEndEvent, false);
+                    window.removeEventListener(eCancel, onEndEvent, false);
+                }
+                else {
+                    list.el.off(eStart, onStartEvent);
+                    list.w.off(eMove, onMoveEvent);
+                    list.w.off(eEnd, onEndEvent);
+                }
 
                 list.el.off('click');
                 list.el.unbind('destroy-nestable');
@@ -206,14 +206,14 @@
             };
 
             list.el.bind('destroy-nestable', destroyNestable);
-			
+
         },
-		
+
         destroy: function ()
         {
             this.el.trigger('destroy-nestable');
         },
-		
+
         _build: function() {
             function escapeHtml(text) {
                 var map = {
@@ -432,6 +432,8 @@
 
         setParent: function(li) {
             if(li.children(this.options.listNodeName).length) {
+                // make sure NOT showing two or more sets data-action buttons
+                li.children('[data-action]').remove();
                 li.prepend($(this.options.expandBtnHTML));
                 li.prepend($(this.options.collapseBtnHTML));
             }

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -184,9 +184,36 @@
                 list.w.on(eMove, onMoveEvent);
                 list.w.on(eEnd, onEndEvent);
             }
+			
+            var destroyNestable = function()
+            {
+           	 	if(hasTouch) {
+              	  list.el[0].removeEventListener(eStart, onStartEvent, false);
+              	  window.removeEventListener(eMove, onMoveEvent, false);
+              	  window.removeEventListener(eEnd, onEndEvent, false);
+              	  window.removeEventListener(eCancel, onEndEvent, false);
+          	  	}
+          	  	else {
+              	  list.el.off(eStart, onStartEvent);
+               	  list.w.off(eMove, onMoveEvent);
+              	  list.w.off(eEnd, onEndEvent);
+				}
 
+                list.el.off('click');
+                list.el.unbind('destroy-nestable');
+
+                list.el.data("nestable", null);
+            };
+
+            list.el.bind('destroy-nestable', destroyNestable);
+			
         },
-
+		
+        destroy: function ()
+        {
+            this.el.trigger('destroy-nestable');
+        },
+		
         _build: function() {
             function escapeHtml(text) {
                 var map = {

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -403,6 +403,8 @@
             this.dragDepth = 0;
             this.hasNewRoot = false;
             this.pointEl = null;
+            // fixedDepth: dragItemDepth
+            this.dragItemDepth = null;
         },
 
         expandItem: function(li) {
@@ -449,6 +451,8 @@
             var mouse = this.mouse,
                 target = $(e.target),
                 dragItem = target.closest(this.options.itemNodeName);
+            // fixedDepth: store dragItem Original depth
+            this.dragItemDepth = dragItem.parents(this.options.listNodeName).length;
 
             this.options.onDragStart.call(this, this.el, dragItem);
 
@@ -606,6 +610,8 @@
              * move horizontal
              */
             if(mouse.dirAx && mouse.distAxX >= opt.threshold) {
+                // fixedDepth: not allow to move horizontal.
+                if(opt.fixedDepth){ return; }
                 // reset move distance on x-axis for new phase
                 mouse.distAxX = 0;
                 prev = this.placeEl.prev(opt.itemNodeName);
@@ -677,8 +683,8 @@
                     return;
                 }
 
-                // fixed item's depth, use for some list has specific type, eg:'Volume, Section, Chapter ...'
-                if(this.options.fixedDepth && this.dragDepth + 1 !== this.pointEl.parents(opt.listNodeName).length) {
+                // fixedDepth: check the poinetEl depth, must be same as  dragItem original Depth
+                if(opt.fixedDepth && this.dragItemDepth !== this.pointEl.parents(opt.listNodeName).length) {
                     return;
                 }
 


### PR DESCRIPTION
Record the item original depth in dragStart, and compare with pointEl’s
Depth.
Disable horizontal move.
